### PR TITLE
Fixed incorrect restriction of auto layout

### DIFF
--- a/TabPageViewController/TabPageController/TabPage.storyboard
+++ b/TabPageViewController/TabPageController/TabPage.storyboard
@@ -10,46 +10,6 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Detail View Controller-->
-        <scene sceneID="PWR-fL-CC1">
-            <objects>
-                <viewController storyboardIdentifier="DetailViewController" id="FcC-Hx-suT" customClass="DetailViewController" customModule="TabPageViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="mv5-Yq-azu"/>
-                        <viewControllerLayoutGuide type="bottom" id="IHs-vf-fMO"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="1Zg-fx-oJM">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qmL-cc-lpd">
-                                <rect key="frame" x="143" y="274" width="89" height="119"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="89" id="HIB-7e-cWQ"/>
-                                    <constraint firstAttribute="height" constant="119" id="gjz-xr-JNr"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="53"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="qmL-cc-lpd" firstAttribute="centerX" secondItem="1Zg-fx-oJM" secondAttribute="centerX" id="ALh-hh-oAg"/>
-                            <constraint firstItem="qmL-cc-lpd" firstAttribute="centerY" secondItem="1Zg-fx-oJM" secondAttribute="centerY" id="P1Y-Vn-DIt"/>
-                        </constraints>
-                        <viewLayoutGuide key="safeArea" id="WaS-yZ-oHv"/>
-                    </view>
-                    <toolbarItems/>
-                    <nil key="simulatedBottomBarMetrics"/>
-                    <connections>
-                        <outlet property="viewLabel" destination="qmL-cc-lpd" id="FNN-sq-3nk"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="bbb-Qh-lPu" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1688.8" y="-102.09895052473765"/>
-        </scene>
         <!--Navigation Controller-->
         <scene sceneID="eu3-1T-yHu">
             <objects>
@@ -145,11 +105,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="39H-Kx-xZz">
-                                                    <rect key="frame" x="29.5" y="0.0" width="66" height="23"/>
+                                                    <rect key="frame" x="58.5" y="0.0" width="8" height="23"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="23" id="KA2-Sc-mnQ"/>
-                                                        <constraint firstAttribute="width" constant="66" id="q52-g4-KBv"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" name="HiraMinProN-W3" family="Hiragino Mincho ProN" pointSize="13"/>
                                                     <color key="textColor" red="0.27058823529999998" green="0.58823529409999997" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
fix bellow

TabPageViewController[11597:1298223] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x1c0094690 h=--& v=--& UIView:0x10192d4a0.width == 74   (active)>",
    "<NSLayoutConstraint:0x1c0092160 UILabel:0x10192d680'Six'.width == 66   (active)>",
    "<NSLayoutConstraint:0x1c0092250 UILabel:0x10192d680'Six'.centerX == UIView:0x10192d4a0.centerX   (active)>",
    "<NSLayoutConstraint:0x1c0092340 H:|-(>=5)-[UILabel:0x10192d680'Six']   (active, names: '|':UIView:0x10192d4a0 )>"
)


Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x1c0092160 UILabel:0x10192d680'Six'.width == 66   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKit/UIView.h> may also be helpful.